### PR TITLE
Make variant optional

### DIFF
--- a/src/components/ui/common/Product/Product.jsx
+++ b/src/components/ui/common/Product/Product.jsx
@@ -114,16 +114,16 @@ class Product extends Component {
             { state } = this.optionsRef,
             ids = map(state, option => option.id),
             { product } = this.state,
-            variantId = find(product.variants,
+            variant = find(product.variants,
                 ({ option_value_ids }) => reduce(ids,
                     (memo, id) => memo && includes(option_value_ids, id),
-                    true)).id;
+                    true));
 
         this.getCart()
                 .then(data => this.context.executeAction('cart/addProduct', {
                     id: data.id,
                     product,
-                    variant_id: variantId
+                    variant_id: variant && variant.id
                 }))
                 .then(() => this.setState({ showProceedToCheckoutLink: true }));
     };


### PR DESCRIPTION
Handle the case where no variants exist on the product.

Note: the API will also accept `options` and apply variants based on option value IDs alone, but this code doesn't handle that yet.